### PR TITLE
Bump version of pyhiveapi and change to pyhive-integration

### DIFF
--- a/custom_components/hive/manifest.json
+++ b/custom_components/hive/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {
     "models": ["HHKBridge*"]
   },
-  "requirements": ["pyhiveapi==0.5.16"],
+  "requirements": ["pyhive-integration==1.0.2"],
   "codeowners": ["@KJonline"],
   "iot_class": "cloud_polling",
   "loggers": ["apyhiveapi"]


### PR DESCRIPTION
PR to fix bug https://github.com/Pyhass/Hive-Custom-Component/issues/169

This PR bumps the version of pyhiveapi and also changes it to use pyhive-integration, which was adopted recently in hacore. There's a fix to the issue being experienced in pyhiveapi 1.0.2

I've tested this change in my HA environment and it appears to resolve the issue