### PR TITLE
Update __init__.py to support async_forward_entry_setups

### DIFF
--- a/custom_components/hive/__init__.py
+++ b/custom_components/hive/__init__.py
@@ -93,12 +93,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except HiveReauthRequired as err:
         raise ConfigEntryAuthFailed from err
 
+    # Collect platforms that have devices
+    platforms_to_setup = []
     for ha_type, hive_type in PLATFORM_LOOKUP.items():
         device_list = devices.get(hive_type)
         if device_list:
-            hass.async_create_task(
-                hass.config_entries.async_forward_entry_setup(entry, ha_type)
-            )
+            platforms_to_setup.append(ha_type)
+
+    # Set up all platforms with devices in a single call
+    if platforms_to_setup:
+        await hass.config_entries.async_forward_entry_setups(entry, platforms_to_setup)
 
     return True
 


### PR DESCRIPTION
Update __init__.py to support async_forward_entry_setups

This is to fix issue #176 and add support for HA 2025.6 as per this blog article:

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/